### PR TITLE
Add Dockerfile for Stats

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+data/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ COPY migrations/ /app/migrations
 COPY ui/ /app/ui
 COPY --from=diesel-builder /app/bin/diesel /app
 COPY --from=builder /app/target/release/stats /app
-COPY --chmod=0755 docker-entrypoint.sh /app
 
 ENV PATH="/app:${PATH}"
+EXPOSE ${SERVICE_PORT}
 
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD diesel migration run && stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --bin stats
+
+FROM rust AS diesel-builder
+
+RUN apt update && \
+    apt install -y libsqlite3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+RUN cargo install diesel_cli --no-default-features --features sqlite --root /app
+
+# We do not need the Rust toolchain to run the binary!
+FROM debian:bookworm-slim AS runtime
+WORKDIR /app
+
+ENV APP_URL=http://127.0.0.1:5775
+ENV SERVICE_PORT=5775
+ENV DATABASE_URL=/app/data/stats.sqlite
+ENV PROCESSING_BATCH_SIZE=500
+# comma-seperated
+ENV CORS_DOMAINS=http://localhost:5775
+
+RUN apt update && \
+    apt install -y libsqlite3-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy necessary files to /data
+WORKDIR /app
+
+ADD https://git.io/GeoLite2-City.mmdb /app/data/GeoLite2-City.mmdb
+ADD https://github.com/PrismaPhonic/filter-cities-by-country/raw/master/cities5000.txt /app/data/cities5000.txt
+
+COPY migrations/ /app/migrations
+COPY ui/ /app/ui
+COPY --from=diesel-builder /app/bin/diesel /app
+COPY --from=builder /app/target/release/stats /app
+COPY --chmod=0755 docker-entrypoint.sh /app
+
+ENV PATH="/app:${PATH}"
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-diesel migration run
-stats

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+diesel migration run
+stats


### PR DESCRIPTION
This PR adds the Dockerfile for Stats that simplifies the deployment. The layer caching has been optimized.

Note that this is in *WIP*: I am still working on the server listening issues (it did not respond to any requests)

