### PR TITLE
Add create-collector endpoint for API

### DIFF
--- a/src/api.http
+++ b/src/api.http
@@ -1,7 +1,10 @@
 ### A documentation file for the API 
 
 ### Record an event with a name and a URL
-http://localhost:5775/collect?collector_id=String&name=String&url=String
+GET http://localhost:5775/collect?collector_id=String&name=String&url=String
+
+### Create a collector
+POST http://localhost:5775/create-collector
 
 ### List last 100 events
 GET http://localhost:5775/events HTTP/1.1

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(events_queue.clone()))
             .route("/collect", web::get().to(events::record_event))
+            .route("/create-collector", web::post().to(collector::post_collector))
             .route("/sessions", web::get().to(sessions::retrieve_sessions))
             .route("/sessions/map", web::get().to(sessions::map))
             .route("/summary", web::get().to(summary::events))


### PR DESCRIPTION
First, I want to start with a thank you for building this in public.  I was thrilled to run into this project on X a couple weeks ago, it was a much cleaner and well written version of something I felt I would need to build myself for my small suite of personal projects.

This PR adds the ```localhost:5775/create-collector``` endpoint.  My personal projects are mainly API based that often don't have a JS integration.  By adding this endpoint, I can create a collector via API without pulling the JS and leverage the IP lookup functionality and properly capture sessions of actions.

Rust is not my strongest language so please let me know if anything needs to be reformatted or fixed!